### PR TITLE
Backwards move restrict cm

### DIFF
--- a/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Bishop.java
+++ b/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Bishop.java
@@ -32,7 +32,9 @@ public class Bishop extends Piece {
 		 */
 		int quadrant = BoardUtilities.getQuadrantCoordinates(this.piecePosition);
 		int column = BoardUtilities.getColumn(this.piecePosition);
-		boolean backwards = false; // keep track if backwards was added to legal
+		// keep track if backwards was added to legal
+		boolean backwards1 = false;// multiples of 8
+		boolean backwards2 = false;// multiples of 6
 									// moves yet or not
 
 		/**
@@ -41,11 +43,13 @@ public class Bishop extends Piece {
 		 */
 		for (int candidateOffset : CANDIDATE_MOVE_COORDINATES) {
 			int candidateDestinationCoordinate = this.piecePosition;
+			// check if backwards is set
+			// add offset and check if new destination is valid
+			
+			if (this.Q1.contains(this.piecePosition) && candidateOffset == -8 && !backwards1) {
+				System.out.println("check 1");
+				backwards1 = true;
 
-			// while coordinate is still in bounds
-			while (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
-
-				// add offset and check if new destination is valid
 				candidateDestinationCoordinate += candidateOffset;
 
 				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
@@ -71,7 +75,431 @@ public class Bishop extends Piece {
 					// there is some piece there. Find out what it is and do
 					// stuff
 					else {
-						
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+
+			if (this.Q1.contains(this.piecePosition) && candidateOffset == 6 && !backwards2) {
+				System.out.println("check 2");
+				backwards2 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			//check quad 2
+			if (this.Q2.contains(this.piecePosition) && candidateOffset == -8 && !backwards1) {
+				System.out.println("check 3");
+				backwards1 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			if (this.Q2.contains(this.piecePosition) && candidateOffset == -6 && !backwards2) {
+				System.out.println("check 4");
+				backwards2 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			//check quad 3 
+			if (this.Q3.contains(this.piecePosition) && candidateOffset == 8 && !backwards1) {
+				System.out.println("check 5");
+				backwards1 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			if (this.Q3.contains(this.piecePosition) && candidateOffset == -6 && !backwards2) {
+				System.out.println("check 5");
+				backwards2 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			//check quad 4
+			if (this.Q4.contains(this.piecePosition) && candidateOffset == 8 && !backwards1) {
+				backwards1 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			if (this.Q4.contains(this.piecePosition) && candidateOffset == 6 && !backwards2) {
+				backwards2 = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+
+			// while coordinate is still in bounds
+			while (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
 						// get the piece at this location
 						final Piece pieceAtDestination = candidateTile.getPiece();
 

--- a/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Piece.java
+++ b/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Piece.java
@@ -1,7 +1,10 @@
 package edu.colostate.cs.cs414.teamthebestteam.rollerball.pieces;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import edu.colostate.cs.cs414.teamthebestteam.rollerball.gameboard.Board;
 import edu.colostate.cs.cs414.teamthebestteam.rollerball.gameboard.Move;
@@ -13,6 +16,10 @@ public abstract class Piece {
 	protected final boolean isFirstMove;
 	protected final boolean didRebound; //only apply's to rook and bishop
 	protected final PieceType pieceType;
+	protected final Set<Integer> Q1;
+	protected final Set<Integer> Q2;
+	protected final Set<Integer> Q3;
+	protected final Set<Integer> Q4;
 	
 	Piece(PieceType pieceType, final int piecePosition, final Alliance pieceAlliance ){
 		this.piecePosition = piecePosition;
@@ -20,6 +27,44 @@ public abstract class Piece {
 		this.isFirstMove = false;
 		this.didRebound = false;
 		this.pieceType = pieceType;
+		Q1 = quad1();
+		Q2 = quad2();
+		Q3 = quad3();
+		Q4 = quad4();
+	}
+	
+	//Quadrant sets to be used for backwards movements
+	//quad1
+	private Set<Integer> quad1() {
+		Set<Integer> quadrant = new HashSet<>();
+		for(int i = 0; i < 12; i++){
+			if(i != 5 || i != 6){
+				quadrant.add(i);
+			}
+		}
+		return quadrant;
+	}
+	//quad2
+	private Set<Integer> quad2() {
+		Integer[] quad_two = { 5,6,12,13,19,20,26,27,33,34 };
+		Set<Integer> quadrant = new HashSet<>(Arrays.asList(quad_two));
+		return quadrant;
+	}
+	//quad3
+	private Set<Integer> quad3(){
+		Set<Integer> quadrant = new HashSet<>();
+		for(int i = 37; i < 49; i++){
+			if(i != 42 || i != 43){
+				quadrant.add(i);
+			}
+		}
+		return quadrant;
+	}
+	//quad4
+	private Set<Integer> quad4(){
+		Integer[] quad_four = { 42,43,35,36,28,29,21,22,14,15 } ;
+		Set<Integer> quadrant = new HashSet<>(Arrays.asList(quad_four));
+		return quadrant;
 	}
 	
 	@Override

--- a/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Rook.java
+++ b/src/edu/colostate/cs/cs414/teamthebestteam/rollerball/pieces/Rook.java
@@ -59,7 +59,221 @@ public class Rook extends Piece{
 		for(int candidateOffset : CANDIDATE_MOVE_COORDINATES)
 		{
 			int candidateDestinationCoordinate = this.piecePosition;
+			
+			//check for backwards move
+			if (this.Q1.contains(this.piecePosition) && candidateOffset == -1 && !backwards) {
+				System.out.println("check 1rook");
+				backwards = true;
 
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+
+			//check quad 2
+			if (this.Q2.contains(this.piecePosition) && candidateOffset == 7 && !backwards) {
+				System.out.println("check 2rook");
+				backwards = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			//check quad 3
+			if (this.Q3.contains(this.piecePosition) && candidateOffset == 1 && !backwards) {
+				System.out.println("check 3rook");
+				backwards = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
+			
+			//check quad 4
+			if (this.Q4.contains(this.piecePosition) && candidateOffset == -7 && !backwards) {
+				System.out.println("check 4rook");
+				backwards = true;
+
+				candidateDestinationCoordinate += candidateOffset;
+
+				if (BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate)) {
+					// get tile of the board of the destination coordinate where
+					// you want to move your piece
+					final Tile candidateTile = board.getTile(candidateDestinationCoordinate);
+
+					// if tile is NOT occupied add to the list of valid moves
+					// and continue back to while loop
+					if (!candidateTile.isTileOccupided()) {
+						/*
+						 * if(backwards = true && (!(quadrant == 3 &&
+						 * candidateOffset == 1) || !(quadrant == 1 &&
+						 * candidateOffset == -1) || !(quadrant == 2 &&
+						 * candidateOffset == -7) || !(quadrant == 4 &&
+						 * candidateOffset == 7))) { legalMove.add(new
+						 * Move.BasicMove(board, this,
+						 * candidateDestinationCoordinate)); }
+						 */
+
+						legalMove.add(new Move.BasicMove(board, this, candidateDestinationCoordinate));
+					}
+					// there is some piece there. Find out what it is and do
+					// stuff
+					else {
+
+						// get the piece at this location
+						final Piece pieceAtDestination = candidateTile.getPiece();
+
+						// get the association of the piece
+						final Alliance pieceAlliance = pieceAtDestination.getPieceAssociation();
+
+						// if THIS piece that we are examining is not = to piece
+						// association that is at our destination tile
+						// we know this is an enemy piece. So do a capture move
+						if (this.pieceAlliance != pieceAlliance) {
+							// need board, piece, destination tile, and piece
+							// that is being captured
+							System.out.println("ATTACK!!!!!");
+							legalMove.add(new Move.CaptureMove(board, this, candidateDestinationCoordinate,
+									pieceAtDestination));
+						}
+						break; // break when we encounter an occupied tile
+					}
+				} // end if isValidTileCoordinate
+				continue;
+
+			}
 			//while coordinate is still in bounds
 			while(BoardUtilities.isValidTileCoordinate(candidateDestinationCoordinate))
 			{


### PR DESCRIPTION
To test just start a game and try to move the bishop or rook backwards more than one space at a time. There are some weird capabilities of the rook to move sideways a long ways even though it appears to be backwards. Not sure if this is okay or if rules state otherwise. CM